### PR TITLE
More context and description for API spec chapter

### DIFF
--- a/spec/8-service-apis.md
+++ b/spec/8-service-apis.md
@@ -1,14 +1,16 @@
 # 8 Service APIs
 
-This section describes external APIs that must be implemented by the building block. Additional APIs may be implemented by the building block (all APIs must adhere to the standards and protocols defined), but the listed APIs define a minimal set that must be provided by any implementation. 
+This section describes external APIs that must be implemented by the building block. Additional APIs may be implemented by the building block (all APIs must adhere to the standards and protocols defined), but the listed APIs define a minimal set that must be provided by any implementation.
 
 The current API specification can be found here:
 
 * [API and Data model main definition document](https://docs.google.com/spreadsheets/d/1snIszqyTGYk1u25liwQ_1jONTsQeH7D8aqv1Td74xt4/edit?usp=sharing) _(for commenting)_
-* [Pull-Request for 0.8 API spec](https://github.com/GovStackWorkingGroup/BuildingBlockAPI/pull/15) _(Raise PR if you want to suggest a change)_
+* [OpenAPI spec in GitHub](https://github.com/GovStackWorkingGroup/bb-consent/) _(Raise PR if you want to suggest a change)_
 * [Latest version rendered API spec](https://app.swaggerhub.com/apis/GovStack/consent-management-bb) _(view only)_
 
-**NOTE:** _Changes to the API definitions can be made by submitting a Pull Request on [this repository](https://github.com/GovStackWorkingGroup/BuildingBlockAPI/pull/15)_
+**NOTE 1:** The API version follows the general version of the Consent BB and is released with the Consent BB as a whole. However, the API is currently undergoing review, refinements and redesign. Please consult the Consent BB Working Group for more guidance on the current versioning semantics.
+
+**NOTE 2:** _Changes to the API definitions can be made by submitting a Pull Request on [this repository](https://github.com/GovStackWorkingGroup/BuildingBlockAPI/pull/15)_
 
 <!--
 ### TODO

--- a/spec/8-service-apis.md
+++ b/spec/8-service-apis.md
@@ -8,10 +8,14 @@ The current API specification can be found here:
 * [OpenAPI spec in GitHub](https://github.com/GovStackWorkingGroup/bb-consent/) _(Raise PR if you want to suggest a change)_
 * [Latest version rendered API spec](https://app.swaggerhub.com/apis/GovStack/consent-management-bb) _(view only)_
 
-**NOTE 1:** The API version follows the general version of the Consent BB and is released with the Consent BB as a whole. However, the API is currently undergoing review, refinements and redesign. Please consult the Consent BB Working Group for more guidance on the current versioning semantics.
+{% hint style="warning" %}
+The API version follows the general version of the Consent BB and is released with the Consent BB as a whole. However, the API is currently undergoing review, refinements and redesign. Please consult the Consent BB Working Group for more guidance on the current versioning semantics.
+{% endhint %}
 
-**NOTE 2:** _Changes to the API definitions can be made by submitting a Pull Request on [this repository](https://github.com/GovStackWorkingGroup/BuildingBlockAPI/pull/15)_
-
+{% hint style="info" %}
+Changes to the API definitions can be made by submitting a Pull Request on [this repository](https://github.com/GovStackWorkingGroup/bb-consent/)
+{% endhint %}
+​
 <!--
 ### TODO
 


### PR DESCRIPTION
I promised earlier to add some kind of guidance on the maturity of the API spec.

I believe we can make use of these types of boxes: https://docs.gitbook.com/tour/editor/blocks/hint