### PR TITLE
Tiny fix for pytest path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Test and docker stuff
 test/gherkin/test_data/
+test/gherkin/result/
 test/*/results
 
 # Byte-compiled / optimized / DLL files

--- a/test/gherkin/Dockerfile
+++ b/test/gherkin/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /tests/
 ENV CONSENTBB_API_HOST=localhost:8888
 ENV CONSENTBB_API_PATH=/api
 
-CMD pytest --cucumberjson /data/results.json
+CMD pytest --cucumberjson=/data/results.json /tests


### PR DESCRIPTION
It seems that some kind of change somewhere has made the pytest command understand its inputs differently so it was reporting `root: /data` and failing to find .feature files.