### PR TITLE
CON-152: Allow signatures on objects that are not yet saved

### DIFF
--- a/api/GovStack Consent BB API endpoints - endpoints.csv
+++ b/api/GovStack Consent BB API endpoints - endpoints.csv
@@ -24,11 +24,11 @@ API tag: service,,,,,,,,,,,,
 "Read operation for ""Agreement"" object",,,,,,,FALSE,,,,,
 /service/agreement/{agreementId}/,GET,UC-C-PIC-A-003,,,"Agreement, Revision",READ - fetches the latest version of an Agreement,FALSE,,serviceAgreementRead,,org,Agreement
 "Read operation for ""Policy"" object",,,,,,,FALSE,,,,,
-/service/policy/{policyId}/,GET,UC-C-PIC-A-003,,,"Policy, Revision",READ - fetches the latest version of a Policy,FALSE,,servicePolicyRead,,org,Policy
+/service/policy/{policyId}/,GET,UC-C-PIC-A-003,,revisionId,"Policy, Revision",READ - fetches the latest version of a Policy and the presented revisionId of an associated Agreement,FALSE,,servicePolicyRead,,org,Policy
 "Read operation for ""Purpose"" object",,,,,,,FALSE,,,,,
-/service/purpose/{purposeId}/,GET,UC-C-PIC-A-003,,,"AgreementPurpose, Revision",READ - fetches the latest version of an AgreementPurpose,FALSE,,serviceAgreementPurposeRead,,org,AgreementPurpose
+/service/purpose/{purposeId}/,GET,UC-C-PIC-A-003,,revisionId,"AgreementPurpose, Revision",READ - fetches the latest version of an AgreementPurpose and the presented revisionId of that Agreement,FALSE,,serviceAgreementPurposeRead,,org,AgreementPurpose
 "List operation for ""AgreementData"" object",,,,,,,FALSE,,,,,
-/service/agreement/{agreementId}/agreementdata/,GET,UC-C-PIC-A-003,,,AgreementData<List>,READ - fetches a list of latest versions of AgreementData associated with an Agreement,FALSE,,serviceAgreementDataRead,,org,AgreementData
+/service/agreement/{agreementId}/agreementdata/,GET,UC-C-PIC-A-003,,revisionId,AgreementData<List>,READ - fetches a list of latest versions of AgreementData associated with an Agreement and the presented revisionId of that Agreement,FALSE,,serviceAgreementDataRead,,org,AgreementData
 Verification mechanisms,,,,,,,FALSE,,,,,
 /service/verification/agreements/,GET,UC-C-PIC-A-003,1.1,AgreementFilter,ConsentRecord<List>,LIST - Fetch consent records for suplied AgreementFilter,FALSE,,serviceVerificationAgreementList,,consumer,
 /service/verification/agreement/{agreementId}/,GET,UC-C-PIC-A-003,1.2,,"ConsentRecord, Revision",READ - Fetch a specific Consent Record (latest revision). Individual ID supplied as HTTP header.,FALSE,,serviceVerificationAgreementConsentRecordRead,,consumer,

--- a/api/GovStack Consent BB API endpoints - schema.csv
+++ b/api/GovStack Consent BB API endpoints - schema.csv
@@ -43,7 +43,7 @@ Model: ConsentRecord,,,"A Consent Record expresses consent (as defined in this b
 id,string,,"Objects may be passed back by some API endpoints without an id (PK), denoting that they are a ""draft"", i.e. a ConsentRecord that is not yet stored in the database and only exist in transit. Draft ConsentRecords do not have a Revision, but if paired up with a Signature, a valid Revision should be generated.",TRUE,FALSE,,,1
 agreement,fk,Agreement,The Agreement to which consent has been given,TRUE,FALSE,GovStack,,1
 agreement_revision,fk,Revision,The Revision of the agreement which consent has been given to,TRUE,FALSE,GovStack,,1
-agreement_revision_hash,string,,Copy of the revision hash. The hash is the included in the signature and ensures against tampering with the original agreement.,TRUE,FALSE,,,
+agreement_revision_hash,string,,Copy of the revision hash. The hash is the included in the signature and ensures against tampering with the original agreement.,TRUE,FALSE,GovStack,,
 individual,fk,Individual,The Individual who has signed this consent record,TRUE,FALSE,GovStack,,1
 opt_in,boolean,,True: The individual has positively opted in. False: The individual has explicitly said no (or withdrawn a previous consent).,FALSE,FALSE,GovStack,,TRUE
 state,string,,The state field is used to record state changes after-the-fact. It is maintained by the Consent BB itself. Valid states: unsigned/pending more signatures/signed,TRUE,FALSE,GovStack,,signed
@@ -55,7 +55,8 @@ Aside from ""successor"" column, a revision should be considered locked.",,,GovS
 id,string,,,TRUE,FALSE,,,
 schema_name,string,,"This was previously called ""schema"" but for technical reasons should be called ""schema_name""",TRUE,FALSE,GovStack,,
 object_id,string,,The PK of the object that was serialized.,TRUE,FALSE,GovStack,,
-serialized_snapshot,string,,"Revisioned data (serialized as JSON) as a dict {object_data: {...}, schema_name: ..., object_id: ..., timestamp: ..., authorized_by_individual: ..., authorized_by_other: ...}. It contains all the fields of the schema except id, successor, predessor_hash and predecessor_signature.",TRUE,FALSE,GovStack,,
+signed_without_object_id,boolean,,Indicates that object_id was left blank in serialized_snapshot when calculating serialized_hash. object_id may be subsequently filled in.,FALSE,TRUE,GovStack,,
+serialized_snapshot,string,,"Revisioned data (serialized as JSON) as a dict {object_data: {...}, schema_name: ..., object_id: ..., signed_without_object_id: ..., timestamp: ..., authorized_by_individual: ..., authorized_by_other: ...}. It contains all the fields of the schema except id, successor, predessor_hash and predecessor_signature.",TRUE,FALSE,GovStack,,
 serialized_hash,string,,Hash of serialized_snapshot (SHA-1),TRUE,FALSE,GovStack,,
 timestamp,string,,Timestamp of when revisioning happened,TRUE,FALSE,GovStack,,
 authorized_by_individual,fk,Individual,,FALSE,TRUE,GovStack,,
@@ -86,7 +87,7 @@ url,string,,URL of data controller (may be omitted if no data involved),TRUE,FAL
 ,,,,,,,,
 Model: Signature,,,"A generic signature contains a cryptographic hash of some value, together with a signature created by some private key in another system. Required signing methods: Revision object or another Signature object.",,,GovStack,,
 id,string,,"Objects may be passed back by some API endpoints without an id (PK), denoting that they are a ""draft"", i.e. a Signature that is not yet stored in the database and only exist in transit.",TRUE,FALSE,,,
-payload,string,,"The payload that is signed, constructed as a JSON serialization of fields {verificiation_payload: ..., verification_payload_hash: ..., verification_method: ..., verification_artifact: ..., verification_signed_by: ..., verification_jws_header, timestamp: ..., object_type: ..., object_reference: ...}. Serialized as a JSON dict.",TRUE,FALSE,,,
+payload,string,,"The final payload that is signed, constructed as a JSON serialization of fields {verificiation_payload: ..., verification_payload_hash: ..., verification_method: ..., verification_artifact: ..., verification_signed_by: ..., verification_jws_header, timestamp: ..., signed_without_object_reference: ..., object_type: ..., object_reference: ...}. Serialized as a JSON dict. If the signature is generated before anything is stored in the database (and has a PK), then the object_reference should be omitted from the payload but filled in afterwards.",TRUE,FALSE,GovStack,,
 signature,string,,"Signature of payload hash, the format of the signature should be specified by either verification_method or verification_jws_header",TRUE,FALSE,GovStack,,
 verification_method,string,,A well-known string denoting which method is used. Valid values: <TBD>. We might expand this with a relation to which verification methods that are supported. There may be a minimal set of supported methods necessary.,TRUE,FALSE,GovStack,Kantara (Consent Receipt Collection Method),
 verification_payload,string,,Internally generated serialized version of the data referenced by object_type and object_reference - by extracting and serializing their data as JSON.,TRUE,FALSE,GovStack,,
@@ -96,6 +97,7 @@ verification_signed_by,string,,"Because an identifier's information may change o
 verification_signed_as,string,,"DRAFT FIELD: Specifies the relationship between the authorizing signature and the invidual which the payload concerns. This is relevant for Consent Records. Possible values: ""individual"" / ""delegate""",FALSE,TRUE,GovStack,,
 verification_jws_header,string,,"Alternative to the verification_method, verification_hash and verification_signature, give a JWS serialized object (RFC7515)",FALSE,TRUE,GovStack,,
 timestamp,string,,"Timestamp of signature, currently this field isn't part of the payload so it's not tamper-proof.",TRUE,TRUE,GovStack,,
+signed_without_object_reference,boolean,,Indicates that object_reference was left blank in the serialized version that was signed.,FALSE,FALSE,GovStack,,
 object_type,string,,"Name of the schema model that object_reference points to. Values: ""signature"" or ""revision""",FALSE,TRUE,GovStack,,
 object_reference,string,,"A symmetric relation / back reference to the object_type that was signed. We are currently just modelling signing another signature (a chain) or signing a Revision (which can be a revision of a consent record, an agreement, policy etc)",FALSE,TRUE,GovStack,,
 ,,,,,,,,

--- a/api/consent-openapi.yaml
+++ b/api/consent-openapi.yaml
@@ -726,14 +726,21 @@ paths:
     get:
       tags:
         - service
-      summary: "READ - fetches the latest version of a Policy"
+      summary: "READ - fetches the latest version of a Policy and the presented revisionId of an associated Agreement"
       operationId: "servicePolicyRead"
-      description: "READ - fetches the latest version of a Policy"
+      description: "READ - fetches the latest version of a Policy and the presented revisionId of an associated Agreement"
       parameters: 
         - in: path
           name: "policyId"
           description: "Unique ID of an object"
           required: true
+          schema:
+            type: string
+
+        - in: query
+          name: revisionId
+          description: "An object with id revisionId"
+          required: false
           schema:
             type: string
 
@@ -765,14 +772,21 @@ paths:
     get:
       tags:
         - service
-      summary: "READ - fetches the latest version of an AgreementPurpose"
+      summary: "READ - fetches the latest version of an AgreementPurpose and the presented revisionId of that Agreement"
       operationId: "serviceAgreementPurposeRead"
-      description: "READ - fetches the latest version of an AgreementPurpose"
+      description: "READ - fetches the latest version of an AgreementPurpose and the presented revisionId of that Agreement"
       parameters: 
         - in: path
           name: "purposeId"
           description: "Unique ID of an object"
           required: true
+          schema:
+            type: string
+
+        - in: query
+          name: revisionId
+          description: "An object with id revisionId"
+          required: false
           schema:
             type: string
 
@@ -804,14 +818,21 @@ paths:
     get:
       tags:
         - service
-      summary: "READ - fetches a list of latest versions of AgreementData associated with an Agreement"
+      summary: "READ - fetches a list of latest versions of AgreementData associated with an Agreement and the presented revisionId of that Agreement"
       operationId: "serviceAgreementDataRead"
-      description: "READ - fetches a list of latest versions of AgreementData associated with an Agreement"
+      description: "READ - fetches a list of latest versions of AgreementData associated with an Agreement and the presented revisionId of that Agreement"
       parameters: 
         - in: path
           name: "agreementId"
           description: "Unique ID of an object"
           required: true
+          schema:
+            type: string
+
+        - in: query
+          name: revisionId
+          description: "An object with id revisionId"
+          required: false
           schema:
             type: string
 
@@ -2147,11 +2168,17 @@ components:
           example: ""
           description: "The PK of the object that was serialized."
 
+        signed_without_object_id:
+          type: boolean
+          format: ""
+          example: ""
+          description: "Indicates that object_id was left blank in serialized_snapshot when calculating serialized_hash. object_id may be subsequently filled in."
+
         serialized_snapshot:
           type: string
           format: ""
           example: ""
-          description: "Revisioned data (serialized as JSON) as a dict {object_data: {...}, schema_name: ..., object_id: ..., timestamp: ..., authorized_by_individual: ..., authorized_by_other: ...}. It contains all the fields of the schema except id, successor, predessor_hash and predecessor_signature."
+          description: "Revisioned data (serialized as JSON) as a dict {object_data: {...}, schema_name: ..., object_id: ..., signed_without_object_id: ..., timestamp: ..., authorized_by_individual: ..., authorized_by_other: ...}. It contains all the fields of the schema except id, successor, predessor_hash and predecessor_signature."
 
         serialized_hash:
           type: string
@@ -2325,7 +2352,7 @@ components:
           type: string
           format: ""
           example: ""
-          description: "The payload that is signed, constructed as a JSON serialization of fields {verificiation_payload: ..., verification_payload_hash: ..., verification_method: ..., verification_artifact: ..., verification_signed_by: ..., verification_jws_header, timestamp: ..., object_type: ..., object_reference: ...}. Serialized as a JSON dict."
+          description: "The final payload that is signed, constructed as a JSON serialization of fields {verificiation_payload: ..., verification_payload_hash: ..., verification_method: ..., verification_artifact: ..., verification_signed_by: ..., verification_jws_header, timestamp: ..., signed_without_object_reference: ..., object_type: ..., object_reference: ...}. Serialized as a JSON dict. If the signature is generated before anything is stored in the database (and has a PK), then the object_reference should be omitted from the payload but filled in afterwards."
 
         signature:
           type: string
@@ -2380,6 +2407,12 @@ components:
           format: ""
           example: ""
           description: "Timestamp of signature, currently this field isn't part of the payload so it's not tamper-proof."
+
+        signed_without_object_reference:
+          type: boolean
+          format: ""
+          example: ""
+          description: "Indicates that object_reference was left blank in the serialized version that was signed."
 
         object_type:
           type: string

--- a/examples/mock/djangoapp/consentbb/app/api_autogenerated.py
+++ b/examples/mock/djangoapp/consentbb/app/api_autogenerated.py
@@ -130,7 +130,7 @@ def service_agreement_read(request, agreementId: str):
 
 
 @api.get("/service/policy/{policyId}/")
-def service_policy_read(request, policyId: str):
+def service_policy_read(request, policyId: str, revisionId: str=None):
     db_instance = get_object_or_404(models.Policy, pk=policyId)
     mocked_instance = G(models.Revision)
     object1 = schemas.PolicySchema.from_orm(db_instance).dict()
@@ -139,7 +139,7 @@ def service_policy_read(request, policyId: str):
 
 
 @api.get("/service/purpose/{purposeId}/")
-def service_agreement_purpose_read(request, purposeId: str):
+def service_agreement_purpose_read(request, purposeId: str, revisionId: str=None):
     db_instance = get_object_or_404(models.AgreementPurpose, pk=purposeId)
     mocked_instance = G(models.Revision)
     object1 = schemas.AgreementPurposeSchema.from_orm(db_instance).dict()
@@ -148,7 +148,7 @@ def service_agreement_purpose_read(request, purposeId: str):
 
 
 @api.get("/service/agreement/{agreementId}/agreementdata/")
-def service_agreement_data_read(request, agreementId: str):
+def service_agreement_data_read(request, agreementId: str, revisionId: str=None):
     db_instance = get_object_or_404(models.AgreementData, pk=agreementId)
     return schemas.AgreementDataSchema.from_orm(db_instance).dict()
 

--- a/examples/mock/djangoapp/consentbb/app/models.py
+++ b/examples/mock/djangoapp/consentbb/app/models.py
@@ -327,9 +327,16 @@ class Revision(models.Model):
         blank=False,
     )
 
+    signed_without_object_id = models.BooleanField(
+        verbose_name="signed_without_object_id",
+        help_text="Indicates that object_id was left blank in serialized_snapshot when calculating serialized_hash. object_id may be subsequently filled in.",
+        null=True,
+        blank=True,
+    )
+
     serialized_snapshot = models.CharField(
         verbose_name="serialized_snapshot",
-        help_text="Revisioned data (serialized as JSON) as a dict {object_data: {...}, schema_name: ..., object_id: ..., timestamp: ..., authorized_by_individual: ..., authorized_by_other: ...}. It contains all the fields of the schema except id, successor, predessor_hash and predecessor_signature.",
+        help_text="Revisioned data (serialized as JSON) as a dict {object_data: {...}, schema_name: ..., object_id: ..., signed_without_object_id: ..., timestamp: ..., authorized_by_individual: ..., authorized_by_other: ...}. It contains all the fields of the schema except id, successor, predessor_hash and predecessor_signature.",
         max_length=1024,
         null=False,
         blank=False,
@@ -421,7 +428,7 @@ class Signature(models.Model):
     
     payload = models.CharField(
         verbose_name="payload",
-        help_text="The payload that is signed, constructed as a JSON serialization of fields {verificiation_payload: ..., verification_payload_hash: ..., verification_method: ..., verification_artifact: ..., verification_signed_by: ..., verification_jws_header, timestamp: ..., object_type: ..., object_reference: ...}. Serialized as a JSON dict.",
+        help_text="The final payload that is signed, constructed as a JSON serialization of fields {verificiation_payload: ..., verification_payload_hash: ..., verification_method: ..., verification_artifact: ..., verification_signed_by: ..., verification_jws_header, timestamp: ..., signed_without_object_reference: ..., object_type: ..., object_reference: ...}. Serialized as a JSON dict. If the signature is generated before anything is stored in the database (and has a PK), then the object_reference should be omitted from the payload but filled in afterwards.",
         max_length=1024,
         null=False,
         blank=False,
@@ -497,6 +504,13 @@ class Signature(models.Model):
         max_length=1024,
         null=False,
         blank=False,
+    )
+
+    signed_without_object_reference = models.BooleanField(
+        verbose_name="signed_without_object_reference",
+        help_text="Indicates that object_reference was left blank in the serialized version that was signed.",
+        null=True,
+        blank=True,
     )
 
     object_type = models.CharField(


### PR DESCRIPTION
## Description

* Allow signatures on objects that are not yet saved
* Add revisionId as a parameter for endpoints that fetch related objects of Agreement

## Related Issue

https://govstack-global.atlassian.net/browse/CON-152?atlOrigin=eyJpIjoiZDBiZDkzZGVmZDc5NGU1M2EyNzcxNjJhODNhYjdiODAiLCJwIjoiaiJ9
