### PR TITLE
Tooling for generating GitBook API spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ The intention is to help with shortcuts for local demos and development of the m
 
 # Launch docker-compose mock application
 ./dev.sh
+
+# Output API spec markdown for GitBook
+./dev.sh gitbook-api-spec
 ```
 
 Once you have the mock application up and running, you can now access several interesting endpoints:

--- a/api/consent-openapi.yaml
+++ b/api/consent-openapi.yaml
@@ -13,14 +13,18 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 tags:
-  - name: config
+  - name: org
     description: Secured operations available to organization API integration
-  - name: service
-    description: Secured operations for individuals, data consumers and applications to record and verify consent
+  - name: dataconsumer
+    description: Secured operations for data consumers and applications to verify consent
+  - name: individual
+    description: Individual operations
   - name: auditor
     description: Operations for external auditing systems to query detailed data from the system and subscribe to notifications.
   - name: notification
     description: Subscribe/unsubscribe notifications for data processors, consumers and frontend systems for individuals.
+  - name: callback
+    description: Callback API for other Building Blocks, especially relevant for asynchronous processes.
 paths:
 
   /config/policy/:

--- a/api/consent-openapi.yaml
+++ b/api/consent-openapi.yaml
@@ -13,18 +13,14 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 tags:
-  - name: org
+  - name: config
     description: Secured operations available to organization API integration
-  - name: dataconsumer
-    description: Secured operations for data consumers and applications to verify consent
-  - name: individual
-    description: Individual operations
+  - name: service
+    description: Secured operations for individuals, data consumers and applications to record and verify consent
   - name: auditor
     description: Operations for external auditing systems to query detailed data from the system and subscribe to notifications.
   - name: notification
     description: Subscribe/unsubscribe notifications for data processors, consumers and frontend systems for individuals.
-  - name: callback
-    description: Callback API for other Building Blocks, especially relevant for asynchronous processes.
 paths:
 
   /config/policy/:

--- a/api/govstack_csv_to_openapi.py
+++ b/api/govstack_csv_to_openapi.py
@@ -1047,6 +1047,64 @@ def generate_django_ninja_api(yaml_data):
     return django_api_template.format(endpoints=django_api_output, VERSION=VERSION)
 
 
+
+def generate_gitbook_api_spec(yaml_data):
+    """
+    Generates .md data for GitBook
+    """
+
+    gitbook_output = ""
+
+    output_by_spec = {
+        "config": [],
+        "service": [],
+        "audit": [],
+        "notification": [],
+        "status": [],
+    }
+
+    for api_url, endpoints in yaml_data["paths"].items():
+
+        for method, endpoint in endpoints.items():
+            section = api_url.split("/")[1]
+            if not section in output_by_spec:
+                raise Exception(section)
+            output_by_spec[section].append(
+                """
+{{% swagger src="https://raw.githubusercontent.com/GovStackWorkingGroup/bb-consent/{version}/api/consent-openapi.yaml" path="{url}" method="{method}" %}}
+[https://raw.githubusercontent.com/GovStackWorkingGroup/bb-consent/{version}/api/consent-openapi.yaml](https://raw.githubusercontent.com/GovStackWorkingGroup/bb-consent/{version}/api/consent-openapi.yaml)
+{{% endswagger %}}""".format(
+                    url=api_url,
+                    method=method,
+                    version=VERSION
+                )
+            )
+
+    print("""
+
+# 8.1 API specification
+
+The following is an automated rendition of our latest [OpenAPI YAML specification](https://github.com/GovStackWorkingGroup/bb-consent/tree/{version}/api).
+""".format(version=VERSION))
+
+    print("""
+## 8.1.1 Config APIs""")
+
+    for output in output_by_spec["config"]:
+        print(output)
+
+    print("""
+## 8.1.2 Service APIs""")
+
+    for output in output_by_spec["service"]:
+        print(output)
+
+    print("""
+## 8.1.3 Audit APIs""")
+
+    for output in output_by_spec["audit"]:
+        print(output)
+
 html_table_output = html_table_template.format(rows=html_table_rows_output)
 
 if len(sys.argv) > 3 and sys.argv[3].strip() == "--html-table":
@@ -1071,6 +1129,11 @@ elif len(sys.argv) > 3 and sys.argv[3].strip() == "--django-admin":
 elif len(sys.argv) > 3 and sys.argv[3].strip() == "--django-api":
 
     output = generate_django_ninja_api(get_yaml())
+    print(output)
+
+elif len(sys.argv) > 3 and sys.argv[3].strip() == "--gitbook-api-spec":
+
+    output = generate_gitbook_api_spec(get_yaml())
     print(output)
 
 else:

--- a/api/govstack_csv_to_openapi.py
+++ b/api/govstack_csv_to_openapi.py
@@ -49,18 +49,14 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 tags:
-  - name: org
+  - name: config
     description: Secured operations available to organization API integration
-  - name: dataconsumer
-    description: Secured operations for data consumers and applications to verify consent
-  - name: individual
-    description: Individual operations
+  - name: service
+    description: Secured operations for individuals, data consumers and applications to record and verify consent
   - name: auditor
     description: Operations for external auditing systems to query detailed data from the system and subscribe to notifications.
   - name: notification
     description: Subscribe/unsubscribe notifications for data processors, consumers and frontend systems for individuals.
-  - name: callback
-    description: Callback API for other Building Blocks, especially relevant for asynchronous processes.
 paths:
 {paths}
 

--- a/dev.sh
+++ b/dev.sh
@@ -39,6 +39,23 @@ then
 
 fi
 
+if [ "$1" == "gitbook-api-spec" ]
+then
+
+  ./api/govstack_csv_to_openapi.py \
+    "api/GovStack Consent BB API endpoints - endpoints.csv" \
+    "api/GovStack Consent BB API endpoints - schema.csv" \
+    > "api/consent-openapi.yaml"
+
+  ./api/govstack_csv_to_openapi.py \
+    "api/GovStack Consent BB API endpoints - endpoints.csv" \
+    "api/GovStack Consent BB API endpoints - schema.csv" \
+    --gitbook-api-spec
+
+  exit
+
+fi
+
 if [ "$1" == "build" ]
 then
   cd ./test/gherkin/


### PR DESCRIPTION
## Description

Tooling used to generate the following change: https://app.gitbook.com/o/pxmRWOPoaU8fUAbbcrus/s/oEAfhW9JLP3tJ6mPyxtF/~/changes/67/8-service-apis#undefined

Reviewers: By auto-generating these contents, I've saved A LOT of time. There's perhaps not so much to review here.

@rachellawson @conradsp if you are spending a lot of time hand-generating these sections in other Building Blocks, consider a similar approach?

## Related Issue

https://govstack-global.atlassian.net/jira/software/c/projects/CON/boards/61?modal=detail&selectedIssue=CON-156
