### PR TITLE
Deactivate security scopes for now

### DIFF
--- a/api/consent-openapi.yaml
+++ b/api/consent-openapi.yaml
@@ -52,8 +52,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
       requestBody:
         content:
@@ -115,8 +115,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -154,8 +154,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
       requestBody:
         content:
@@ -206,8 +206,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -259,8 +259,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -315,8 +315,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [admin]
+#      security:
+#        - OAuth2: [admin]
 
 
 
@@ -356,8 +356,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -395,8 +395,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
       requestBody:
         content:
@@ -447,8 +447,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -481,8 +481,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
       requestBody:
         content:
@@ -545,8 +545,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -577,8 +577,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
       requestBody:
         content:
@@ -631,8 +631,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -680,8 +680,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -712,8 +712,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [admin]
+#      security:
+#        - OAuth2: [admin]
 
       requestBody:
         content:
@@ -773,8 +773,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [admin]
+#      security:
+#        - OAuth2: [admin]
 
 
 
@@ -810,8 +810,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [admin]
+#      security:
+#        - OAuth2: [admin]
 
       requestBody:
         content:
@@ -854,8 +854,8 @@ paths:
             
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [admin]
+#      security:
+#        - OAuth2: [admin]
 
 
 
@@ -910,8 +910,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [admin]
+#      security:
+#        - OAuth2: [admin]
 
 
 
@@ -942,8 +942,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
       requestBody:
         content:
@@ -996,8 +996,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -1033,8 +1033,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
       requestBody:
         content:
@@ -1097,8 +1097,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -1138,8 +1138,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -1186,8 +1186,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [org]
+#      security:
+#        - OAuth2: [org]
 
 
 
@@ -1235,8 +1235,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [consumer]
+#      security:
+#        - OAuth2: [consumer]
 
 
 
@@ -1284,8 +1284,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [consumer]
+#      security:
+#        - OAuth2: [consumer]
 
 
 
@@ -1325,8 +1325,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [consumer]
+#      security:
+#        - OAuth2: [consumer]
 
 
 
@@ -1380,8 +1380,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
 
 
@@ -1417,8 +1417,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
 
 
@@ -1472,8 +1472,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
 
 
@@ -1508,8 +1508,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
       requestBody:
         content:
@@ -1576,8 +1576,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
 
 
@@ -1617,8 +1617,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
       requestBody:
         content:
@@ -1671,8 +1671,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
       requestBody:
         content:
@@ -1723,8 +1723,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
       requestBody:
         content:
@@ -1794,8 +1794,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
 
 
@@ -1818,8 +1818,8 @@ paths:
             
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [individual]
+#      security:
+#        - OAuth2: [individual]
 
 
 
@@ -1867,8 +1867,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: []
+#      security:
+#        - OAuth2: []
 
 
 
@@ -1906,8 +1906,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: []
+#      security:
+#        - OAuth2: []
 
 
 
@@ -1955,8 +1955,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: []
+#      security:
+#        - OAuth2: []
 
 
 
@@ -1994,8 +1994,8 @@ paths:
 
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: []
+#      security:
+#        - OAuth2: []
 
 
 
@@ -2622,22 +2622,22 @@ components:
 
 
 
-  securitySchemes:
-    OAuth2:
-      type: oauth2
-      flows:
-        authorizationCode:
-          authorizationUrl: https://example.com/oauth/authorize
-          tokenUrl: https://example.com/oauth/token
-          scopes:
-            read: Grants global read access
-            write: Grants global write access
-            org: Grants access to org operations
-            consumer: Grants access to data consumer operations
-            individual: Grants access to specific individual read/write operations
-            auditor: Grants access to specific auditor read operations
+#  securitySchemes:
+#    OAuth2:
+#      type: oauth2
+#      flows:
+#        authorizationCode:
+#          authorizationUrl: https://example.com/oauth/authorize
+#          tokenUrl: https://example.com/oauth/token
+#          scopes:
+#            read: Grants global read access
+#            write: Grants global write access
+#            org: Grants access to org operations
+#            consumer: Grants access to data consumer operations
+#            individual: Grants access to specific individual read/write operations
+#            auditor: Grants access to specific auditor read operations
 
-security:
-  - OAuth2:
-      - read
+#security:
+#  - OAuth2:
+#      - read
 

--- a/api/govstack_csv_to_openapi.py
+++ b/api/govstack_csv_to_openapi.py
@@ -64,24 +64,24 @@ components:
   schemas:
 {schemas}
 
-  securitySchemes:
-    OAuth2:
-      type: oauth2
-      flows:
-        authorizationCode:
-          authorizationUrl: https://example.com/oauth/authorize
-          tokenUrl: https://example.com/oauth/token
-          scopes:
-            read: Grants global read access
-            write: Grants global write access
-            org: Grants access to org operations
-            consumer: Grants access to data consumer operations
-            individual: Grants access to specific individual read/write operations
-            auditor: Grants access to specific auditor read operations
+#  securitySchemes:
+#    OAuth2:
+#      type: oauth2
+#      flows:
+#        authorizationCode:
+#          authorizationUrl: https://example.com/oauth/authorize
+#          tokenUrl: https://example.com/oauth/token
+#          scopes:
+#            read: Grants global read access
+#            write: Grants global write access
+#            org: Grants access to org operations
+#            consumer: Grants access to data consumer operations
+#            individual: Grants access to specific individual read/write operations
+#            auditor: Grants access to specific auditor read operations
 
-security:
-  - OAuth2:
-      - read
+#security:
+#  - OAuth2:
+#      - read
 """
 
 path_spec_template = """
@@ -102,8 +102,8 @@ path_spec_template = """
             {responseOK_objects}
         '400':
           description: bad input parameter
-      security:
-        - OAuth2: [{security}]
+#      security:
+#        - OAuth2: [{security}]
 {request_body}
 """
 

--- a/examples/mock/Dockerfile_caddy
+++ b/examples/mock/Dockerfile_caddy
@@ -1,6 +1,6 @@
 FROM caddy:2.7.3-builder AS builder
 
-RUN xcaddy build --with github.com/chukmunnlee/caddy-openapi@v0.7.0
+RUN xcaddy build --with github.com/chukmunnlee/caddy-openapi@v0.9.0
 
 FROM caddy:2.7.3-alpine
 


### PR DESCRIPTION
This should make it possible to symlink the openapi spec in https://github.com/GovStackWorkingGroup/bb-consent/pull/67 (rather than creating a hard-copy)